### PR TITLE
Remove Mac Catalyst warnings related to deprecated accessibility options

### DIFF
--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -231,13 +231,21 @@
             accessibility = kSecAttrAccessibleAfterFirstUnlock;
             break;
         case A0SimpleKeychainItemAccessibleAlways:
+#if TARGET_OS_MACCATALYST
+            accessibility = kSecAttrAccessibleAfterFirstUnlock;
+#else
             accessibility = kSecAttrAccessibleAlways;
+#endif
             break;
         case A0SimpleKeychainItemAccessibleAfterFirstUnlockThisDeviceOnly:
             accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
             break;
         case A0SimpleKeychainItemAccessibleAlwaysThisDeviceOnly:
+#if TARGET_OS_MACCATALYST
+            accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
+#else
             accessibility = kSecAttrAccessibleAlwaysThisDeviceOnly;
+#endif
             break;
 #if TARGET_OS_IPHONE
         case A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly:


### PR DESCRIPTION
### Changes

- **kSecAttrAccessibleAlways** and **kSecAttrAccessibleAlwaysThisDeviceOnly** are deprecated on Mac Catalyst due to the fact that does not provide a useful level of protection.  They should be replaced with **kSecAttrAccessibleAfterFirstUnlock** and **kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly** respectively

### References

- https://developer.apple.com/documentation/security/ksecattraccessiblealwaysthisdeviceonly
- https://developer.apple.com/documentation/security/ksecattraccessiblealways

### Testing

[X] Tested on a Mac Catalyst application, this removed the warnings sent by the compiler and still provides a secure storage.

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[X] All existing and new tests complete without errors
